### PR TITLE
V3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
 node_modules/.cache
 *bundle.js*
-*easydb.config.json*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 node_modules/.cache
 *bundle.js*
+*easydb.config.json*

--- a/examples/easydb.config.json
+++ b/examples/easydb.config.json
@@ -3,6 +3,10 @@
     "default": {
       "uuid": "6091c45a-2ca9-4808-bb8d-1dbf42122818",
       "token": "5285d22c-9d1c-4c3a-8eee-ad67e92f1e24"
+    },
+    "alternate": {
+      "uuid": "9785cd23-6a42-4659-8518-713a99c77abb",
+      "token": "750f1876-f8e4-45fe-9f97-87805b893980"
     }
   },
   "url": "https://app.easydb.io"

--- a/examples/easydb.config.json
+++ b/examples/easydb.config.json
@@ -1,0 +1,9 @@
+{
+  "databases": {
+    "default": {
+      "uuid": "6091c45a-2ca9-4808-bb8d-1dbf42122818",
+      "token": "5285d22c-9d1c-4c3a-8eee-ad67e92f1e24"
+    }
+  },
+  "url": "https://app.easydb.io"
+}

--- a/examples/index.js
+++ b/examples/index.js
@@ -2,16 +2,22 @@
 const easyDB = require("easydb-io");
 // import uuid from "uuid/v4";
 
-let db = easyDB({
-  database: "e9189a59-68b3-4cfb-892d-3527c0cf6bac",
-  token: "64eea1c5f3d84401b554f60dda46491d"
-  // url: "http://localhost:8080"
-});
+// let db = easyDB({
+//   database: "e9189a59-68b3-4cfb-892d-3527c0cf6bac",
+//   token: "64eea1c5f3d84401b554f60dda46491d"
+//   // url: "http://localhost:8080"
+// });
 
 const runner = async () => {
   //while (true) {
   // db.Put(uuid(), { [uuid()]: uuid() });
   // db.delete("e22975eb-1506-4881-b1ea-efaad7d44b8d");
+  let db = easyDB.connect({
+    uuid: "9785cd23-6a42-4659-8518-713a99c77abb",
+    token: "750f1876-f8e4-45fe-9f97-87805b893980"
+  });
+  // db.put("hello", "world");
+  //db.put("hello", "Jake");
   const data = await db.list((err, data) => console.log(data));
   console.log(data);
   //}

--- a/examples/index.js
+++ b/examples/index.js
@@ -12,13 +12,11 @@ const runner = async () => {
   //while (true) {
   // db.Put(uuid(), { [uuid()]: uuid() });
   // db.delete("e22975eb-1506-4881-b1ea-efaad7d44b8d");
-  let db = easyDB.connect({
-    uuid: "9785cd23-6a42-4659-8518-713a99c77abb",
-    token: "750f1876-f8e4-45fe-9f97-87805b893980"
-  });
+  //let db = easyDB.connect("alternate");
+  // console.log("IT IS", db.connect);
   // db.put("hello", "world");
   //db.put("hello", "Jake");
-  const data = await db.list((err, data) => console.log(data));
+  const data = await easyDB.list((err, data) => console.log(data));
   console.log(data);
   //}
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,11 @@
         }
       }
     },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -71,6 +76,11 @@
         "@types/node": "*",
         "acorn": "^7.1.0"
       }
+    },
+    "uuid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,14 +2,16 @@
   "name": "easydb-io",
   "version": "2.0.0",
   "description": "EasyDB JavaScript Client",
-  "main": "bundle.js",
+  "main": "./src/index.js",
   "scripts": {
     "build": "rollup -c"
   },
   "author": "jakecooper",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.19.0"
+    "axios": "^0.19.0",
+    "fs": "0.0.1-security",
+    "uuid": "^3.3.3"
   },
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,8 @@ export default {
     format: "umd",
     globals: {
       axios: "Axios"
-    }
+    },
+    name: "easydb"
   },
   external: ["axios"] // <-- suppresses the warning
 };

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,8 @@ let DEFAULT_DB;
 
 if (isNode && fs.existsSync(CONFIG_FILE)) {
   let data = JSON.parse(fs.readFileSync(CONFIG_FILE));
-  DEFAULT_DB = data;
+  let { uuid, token } = data.databases.default;
+  DEFAULT_DB = { uuid, token, url: data.url };
 }
 
 const instanceActions = {
@@ -109,11 +110,36 @@ const constructActions = database => {
   }, {});
 };
 
-const connect = ({ uuid, token, url = BASE_URL }) => {
+const connect = params => {
+  let uuid, token;
+  let configData = JSON.parse(fs.readFileSync(CONFIG_FILE));
+
+  if (typeof params === "string" || params == null) {
+    // Initialize from config
+    if (!params) {
+      // Nothing provided, connect to default
+      params = "default";
+    }
+    if (!configData.databases[params]) {
+      let validChoices = Object.keys(configData.databases)
+        .map(s => ` - ${s}`)
+        .join("\n");
+      throw `Could not find database ${params} in easydb.config.json\n Valid databases are: \n${validChoices}`;
+    }
+    let database = configData.databases[params];
+    uuid = database.uuid;
+    token = database.token;
+  } else if (typeof params === "object") {
+    // Initialize from object
+    uuid = params.uuid;
+    token = params.token;
+  } else {
+    throw "Invalid parameters passed to connect(Object | String)";
+  }
   if (!uuid || !token) {
     throw "uuid and token must be provided";
   }
-  let currentDB = { uuid, token, url };
+  let currentDB = { uuid, token, url: configData.url };
   return constructActions(currentDB);
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,24 @@
-import { get, post, delete as del } from "axios";
+import {
+  get as AxiosGet,
+  post as AxiosPost,
+  delete as AxiosDelete
+} from "axios";
+import fs from "fs";
+import uuid from "uuid/v4";
+
+const BASE_URL = "https://app.easydb.io";
+const CONFIG_FILE = "./easydb.config.json";
+
+const isNode = () => {
+  return typeof process !== "undefined" && process.release.name === "node";
+};
+
+if (isNode && !fs.existsSync(CONFIG_FILE)) {
+  fs.writeFileSync(
+    CONFIG_FILE,
+    JSON.stringify({ uuid: uuid(), token: uuid(), url: BASE_URL }, null, 2)
+  );
+}
 
 const coherseCallback = (axiosPromise, callback) => {
   let p = new Promise((resolve, reject) => {
@@ -22,56 +42,86 @@ const coherseCallback = (axiosPromise, callback) => {
   return callback ? null : p;
 };
 
-const EasyDB = config => {
-  let { database, token, url = `https://app.easydb.io` } = config;
+let DEFAULT_DB;
 
-  return {
-    get: (key, cb) => {
-      return coherseCallback(
-        get(`${url}/database/${database}/${key}`, {
+if (isNode && fs.existsSync(CONFIG_FILE)) {
+  let data = JSON.parse(fs.readFileSync(CONFIG_FILE));
+  DEFAULT_DB = data;
+}
+
+const instanceActions = {
+  get: (DB, key, cb) => {
+    return coherseCallback(
+      AxiosGet(`${DB.url}/database/${DB.uuid}/${key}`, {
+        headers: {
+          token: DB.token
+        }
+      }),
+      cb
+    );
+  },
+  put: (DB, key, value, cb) => {
+    return coherseCallback(
+      AxiosPost(
+        `${DB.url}/database/${DB.uuid}/${key}`,
+        {
+          value
+        },
+        {
           headers: {
-            token
+            "Content-Type": "application/json",
+            token: DB.token
           }
-        }),
-        cb
-      );
-    },
-    put: (key, value, cb) => {
-      return coherseCallback(
-        post(
-          `${url}/database/${database}/${key}`,
-          {
-            value
-          },
-          {
-            headers: {
-              "Content-Type": "application/json",
-              token
-            }
-          }
-        ),
-        cb
-      );
-    },
-    delete: (key, cb) => {
-      return coherseCallback(
-        del(`${url}/database/${database}/${key}`, {
-          headers: {
-            token
-          }
-        }),
-        cb
-      );
-    },
-    list: cb => {
-      return coherseCallback(
-        get(`${url}/database/${database}`, {
-          headers: { token }
-        }),
-        cb
-      );
-    }
-  };
+        }
+      ),
+      cb
+    );
+  },
+  delete: (DB, key, cb) => {
+    return coherseCallback(
+      AxiosDelete(`${DB.url}/database/${DB.uuid}/${key}`, {
+        headers: {
+          token: DB.token
+        }
+      }),
+      cb
+    );
+  },
+  list: (DB, cb) => {
+    return coherseCallback(
+      AxiosGet(`${DB.url}/database/${DB.uuid}`, {
+        headers: { token: DB.token }
+      }),
+      cb
+    );
+  }
 };
 
-module.exports = EasyDB;
+const constructActions = database => {
+  if (!database) {
+    throw "Database uninitialized. Init, connect, or use an easydb.config.json";
+  }
+  return Object.keys(instanceActions).reduce((acc, action) => {
+    acc[action] = (...params) => {
+      instanceActions[action](database, ...params);
+    };
+    return acc;
+  }, {});
+};
+
+const connect = ({ uuid, token, url = BASE_URL }) => {
+  if (!uuid || !token) {
+    throw "uuid and token must be provided";
+  }
+  let currentDB = { uuid, token, url };
+  return constructActions(currentDB);
+};
+
+let actions = {
+  connect,
+  ...constructActions(DEFAULT_DB)
+};
+
+console.log(actions);
+
+module.exports = actions;


### PR DESCRIPTION
This pull requests increments the major version from 2.0 to 3.0

Included: easydb allows you to implicitly or explicitly define a database.

implicit
```
import easyDB from 'easydb-io'

easyDB.put("key", "value");
easyDB.list((err, data) => console.log(data)); // {"key": "value"}
```

explicit
```
import easyDB from 'easydb.io'
let db = easyDB.connect({uuid: "my-uuid", token: "my-token"})
db.put("key", "value");
easyDB.list((err, data) => console.log(data)); // {"key": "value"}
```

EasyDB will define a database to use as a sane default inside an `easydb.config.json` file. This database will be used for all top level actions. connect returns a database which is connected to the server.
